### PR TITLE
Pin openmct version to a tag

### DIFF
--- a/openmct/Dockerfile
+++ b/openmct/Dockerfile
@@ -1,6 +1,7 @@
 from node:19 AS builder
 RUN git clone https://github.com/nasa/openmct.git
 WORKDIR openmct
+RUN	git checkout tags/v2.2.5
 RUN npm update && npm install
 
 from nginx:latest


### PR DESCRIPTION
OpenMCT won't build correctly with versions after 2.2.5 

Will need to properly address later.
Addresses #22